### PR TITLE
Replaced 'date' with 'year'

### DIFF
--- a/_episodes/02-basic-queries.md
+++ b/_episodes/02-basic-queries.md
@@ -31,7 +31,7 @@ If we want more information, we can add a new column to the list of fields,
 right after `SELECT`:
 
 ~~~
-SELECT title, authors, issns, date
+SELECT title, authors, issns, year
 FROM articles;
 ~~~
 {: .sql}


### PR DESCRIPTION
'date' does not exist in the article table, we used 'year' instead.

PS. this is my first pull request, hope it works ok! 
